### PR TITLE
Description character limit and output formatting

### DIFF
--- a/functions/list.js
+++ b/functions/list.js
@@ -107,7 +107,7 @@ function renderEvent(event) {
       <br class="card-text">${dateFormat(event.date, "UTC:dddd, mmmm dS, yyyy")}</br>
       <p class="card-text">${renderTime(event)}Location: ${event.location} <a href="http://maps.google.com?q=${event.location}" target="_blank">(map)</a></p>
       <p class="card-text">---------</p>
-      <p class="card-text">${event.eventDesc}</p>
+      <p class="card-text">${renderDesc(event.eventDesc)}</p>
       <div class="d-flex justify-content-between align-items-center">
         <div class="btn-group">
           <!-- <button type="button" class="btn btn-sm btn-outline-secondary">View</button>
@@ -125,6 +125,10 @@ function renderTime(event) {
     return `${event.startTimeHour}:${event.startTimeMinute} - ${event.endTimeHour}:${event.endTimeMinute} <br> `;
   }
   return '';
+}
+
+function renderDesc(desc) {
+  return desc.trim().replace(/\n/g, '<br>');
 }
 
 // If URL is from Cloudinary, rewrite it to apply a resize transformation

--- a/functions/models/eventItem.js
+++ b/functions/models/eventItem.js
@@ -1,7 +1,8 @@
+require('dotenv').config();
 var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
-const collectionName = 'events'
+const collectionName = process.env.EVENT_COLLECTION || 'events'
 
 // Create Schema
 var eventSchema = new Schema({

--- a/public/create.html
+++ b/public/create.html
@@ -114,8 +114,9 @@
           </span><br>
 
           <label for="eventDesc">Provide a brief description of your event/Insérez une brève description de votre événement</label>
-          <textarea class="pure-input-1-2" name="eventDesc" required></textarea>
+          <textarea class="pure-input-1-2" name="eventDesc" id="eventDesc" required maxlength="400"></textarea>
           <span class="pure-form-message">
+            <span id="eventDescChars">0</span>/400<br>
             Required field/Champ obligatoire
           </span><br>
 
@@ -290,6 +291,21 @@
     window.onbeforeunload = event => {
       loading.style.visibility = 'hidden';
       submitButton.disabled = false;
+    }
+  </script>
+
+
+  <script>
+    var description = document.getElementById('eventDesc'); 
+    var charCount = document.getElementById('eventDescChars'); 
+    updateCharCount(); // update on load
+
+    description.onkeyup = event => {
+      updateCharCount()
+    }
+
+    function updateCharCount() {
+      charCount.innerText = description.value.length
     }
   </script>
 


### PR DESCRIPTION
* Limit number of chars in description and report how many used via visual feedback.
* Replace newlines with <br> tags on event list page in order to preserve them (noticed some user descriptions were being smushed).
* You can now specify EVENT_COLLECTION in .env to override for development purposes

**Limit:**
![eventCharLimInf](https://user-images.githubusercontent.com/19917125/57823177-9151c180-7764-11e9-84e9-fa5386eba814.gif)

**Before:**
<img width="364" alt="Screen Shot 2019-05-15 at 10 49 18 PM" src="https://user-images.githubusercontent.com/19917125/57823283-e7266980-7764-11e9-9913-d1719e538662.png">

**After:**
<img width="358" alt="Screen Shot 2019-05-15 at 10 49 32 PM" src="https://user-images.githubusercontent.com/19917125/57823293-f0173b00-7764-11e9-8f02-090de9b21d33.png">


